### PR TITLE
ability to manage plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new parameter `$plugins` to specify a list of postfix plugins that should be installed (#2)
+- Add new parameter `$plugin` to configure plugin package names (#2)
+- Add new parameter `$package_manage` to control wether packages should be installed or not (#2)
+
 ### Fixed
 - Handle unused main.cf parameters that are unknown by postfix and not referenced
   in any other parameter (#3).
+- Fix service logic: move exec `restart after package install` to class `postfix::package` (#2)
 
 ## Release [0.2.1] - 2018-02-05
 Cosmetic release that removes outdated badges from README

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,3 +1,12 @@
 ---
 postfix::mailx_package: 'bsd-mailx'
+postfix::plugin:
+  ldap:
+    package_name: ['postfix-ldap']
+  mysql:
+    package_name: ['postfix-mysql']
+  pcre:
+    package_name: ['postfix-pcre']
+  pgsql:
+    package_name: ['postfix-pgsql']
 postfix::restart_cmd: '/etc/init.d/postfix reload'

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,3 +1,6 @@
 ---
 postfix::mailx_package: 'mail/heirloom-mailx'
+postfix::plugin:
+  sasl:
+    package_name: ['mail/postfix-sasl']
 postfix::restart_cmd: '/usr/sbin/service postfix reload'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,10 @@ postfix::mailx_package: 'mailx'
 postfix::mailx_ensure: present
 postfix::mailx_manage: true
 postfix::package_ensure: present
+postfix::package_manage: true
 postfix::package_name: 'postfix'
+postfix::plugin: {}
+postfix::plugins: []
 postfix::service_ensure: running
 postfix::service_manage: true
 postfix::service_name: 'postfix'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,10 @@
 # * `package_ensure`
 # The state the postfix package should be ensured.
 #
+# * `package_manage`
+# Whether to install the postfix and plugin packages.
+#
+# * `package_name`
 # * `package_name`
 # The name of the postfix package to install.
 #
@@ -29,6 +33,12 @@
 #
 # * `mailx_package`
 # The name of the mailx package.
+#
+# * `plugin`
+# Contains a package_name parameter for each plugin (if available).
+#
+# * `plugins`
+# The list of plugins to install.
 #
 # Examples
 # --------
@@ -56,7 +66,10 @@ class postfix (
   Boolean $mailx_manage,
   String $mailx_package,
   Enum['installed', 'present', 'latest'] $package_ensure,
+  Boolean $package_manage,
   String $package_name,
+  Hash $plugin,
+  Array[String[1]] $plugins,
   String $restart_cmd,
   Enum['absent', 'running', 'stopped'] $service_ensure,
   String $service_name,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -17,8 +17,17 @@
 #
 class postfix::package inherits postfix {
   if ($postfix::package_manage) {
-    package { $postfix::package_name:
+    package { 'postfix':
       ensure => $postfix::package_ensure,
+      name   => $postfix::package_name,
+    }
+
+    if $::postfix::service_manage {
+      exec { 'restart postfix service after packages install':
+        command     => regsubst($::postfix::restart_cmd, 'reload', 'restart'),
+        refreshonly => true,
+        subscribe   => Package['postfix'],
+      }
     }
 
     # get a list of package names for all requested plugins

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -16,9 +16,25 @@
 # Copyright 2017 Bernhard Frauendienst <puppet@nospam.obeliks.de>
 #
 class postfix::package inherits postfix {
-  package { 'postfix':
-    ensure => $::postfix::package_ensure,
-    name   => $::postfix::package_name,
+  if ($postfix::package_manage) {
+    package { $postfix::package_name:
+      ensure => $postfix::package_ensure,
+    }
+
+    # get a list of package names for all requested plugins
+    $_list = $postfix::plugins.map |$_plugin| {
+      $postfix::plugin.dig($_plugin, 'package_name')
+    }
+
+    # remove duplicates from the list
+    $packages = unique($_list).filter|$value| { $value != undef }
+
+    # install plugin packages
+    $packages.each |$_package| {
+      package { $_package:
+        ensure => $postfix::package_ensure,
+      }
+    }
   }
 
   if ($::postfix::mailx_manage) {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -31,11 +31,6 @@ class postfix::service inherits postfix {
   }
 
   if $::postfix::service_manage {
-    exec { 'restart postfix after packages install':
-      command     => regsubst($::postfix::restart_cmd, 'reload', 'restart'),
-      refreshonly => true,
-      subscribe   => Package['postfix'],
-    }
     service { 'postfix':
       ensure    => $service_ensure_real,
       name      => $::postfix::service_name,


### PR DESCRIPTION
Changes:

* new parameter `$plugins` to specify a list of postfix plugins that should be installed
* new parameter `$plugin` to configure plugin package names (some defaults added to module data)
* new parameter `$package_manage` to control wether packages should be installed by this module or not
* fix service logic: move exec `restart after package install` to class `postfix::package`, otherwise it would be triggered when using something like `notify => Class['postfix::service']`

The plugin mechanism is the same that is being used in https://github.com/oxc/puppet-dovecot. It should be noted that this is mostly required for Debian/Ubuntu.