### PR TITLE
 fix postfix fact: ignore when no postconf binary is found

### DIFF
--- a/lib/facter/postconf.rb
+++ b/lib/facter/postconf.rb
@@ -1,7 +1,6 @@
 Facter.add(:postfix) do
+  confine exists: 'postconf', for_binary: true
   setcode do
-    confine exists: 'postconf', for_binary: true
-
     configs = {
       mail_version: :version,
       config_directory: :default_config_directory,


### PR DESCRIPTION
To avoid errors on unsupported operating systems, i.e. Windows:

```
error while resolving custom fact "postfix": execution of command "postconf -d -x mail_version config_directory data_directory" failed: command not found.
```