### PR TITLE
fix for: undefined method `scan' for nil:NilClass

### DIFF
--- a/lib/puppet/confine/postfix_version.rb
+++ b/lib/puppet/confine/postfix_version.rb
@@ -17,8 +17,9 @@ class Puppet::Confine::PostfixVersion < Puppet::Confine
   end
 
   def self.postfix_version
-    postfix_facts = ::Facter.value(:postfix)
+    postfix_facts = Facter.value(:postfix)
     return :absent if postfix_facts.nil?
-    postfix_facts[:version]
+    postfix_version = postfix_facts[:version]
+    postfix_version.nil? ? :absent : postfix_version
   end
 end


### PR DESCRIPTION
On Puppet 7.9.0 (FreeBSD) I've noticed the following error:

```
# puppet agent -t --noop --trace
Info: Using configured environment 'development'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Failed to apply catalog: undefined method `scan' for nil:NilClass
/usr/local/lib/ruby/site_ruby/2.7/puppet/util/package.rb:4:in `versioncmp'
/var/puppet/lib/puppet/confine/postfix_version.rb:12:in `pass?'
...
```

The following patch seems to fix it and still works on Puppet 6.