### PR TITLE
support unix-dgram type

### DIFF
--- a/lib/puppet/provider/postconf_master/postconf.rb
+++ b/lib/puppet/provider/postconf_master/postconf.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:postconf_master).provide(:postconf, parent: Puppet::Provider:
   def self.postconf_master_hash(path = nil)
     pc_output = postconf_multi(path, '-F')
 
-    pc_output.scan(%r{^(\S+\/\w+)\/(\w+) = (.*)$}).each_with_object({}) do |larray, hash|
+    pc_output.scan(%r{^(\S+\/[\w-]+)\/(\w+) = (.*)$}).each_with_object({}) do |larray, hash|
       hash[larray[0]] ||= {}
       hash[larray[0]][larray[1].to_sym] = larray[2]
       hash

--- a/lib/puppet/type/postconf_master.rb
+++ b/lib/puppet/type/postconf_master.rb
@@ -62,7 +62,7 @@ Puppet::Type.newtype(:postconf_master) do
           (( \[[a-zA-Z0-9.:]+\] | [a-zA-Z0-9.]+ ):)? # optional interface address for inet types
           [a-zA-Z0-9]+/inet                          # (named/numeric) port and inet type
         |
-          [a-zA-Z0-9._/-]+/(unix|fifo|pipe|pass)     # all other services can have socket paths
+          [a-zA-Z0-9._/-]+/(unix|fifo|pipe|pass|unix-dgram)     # all other services can have socket paths
         )$}mx,
     )
   end

--- a/spec/unit/puppet/provider/postconf_master/postconf_spec.rb
+++ b/spec/unit/puppet/provider/postconf_master/postconf_spec.rb
@@ -56,6 +56,14 @@ describe Puppet::Type.type(:postconf_master).provider(:postconf) do
       'maildrop/unix/wakeup = -',
       'maildrop/unix/process_limit = -',
       'maildrop/unix/command = pipe flags=DRhu user=vmail argv=/usr/bin/maildrop -d ${recipient}',
+      'postlog/unix-dgram/service = postlog',
+      'postlog/unix-dgram/type = unix-dgram',
+      'postlog/unix-dgram/private = n',
+      'postlog/unix-dgram/unprivileged = -',
+      'postlog/unix-dgram/chroot = n',
+      'postlog/unix-dgram/wakeup = -',
+      'postlog/unix-dgram/process_limit = 1',
+      'postlog/unix-dgram/command = postlogd',
     ]
   end
 

--- a/spec/unit/puppet/type/postconf_master_spec.rb
+++ b/spec/unit/puppet/type/postconf_master_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:postconf_master) do
   end
 
   describe 'service_type =>' do
-    [:inet, :unix, :fifo, :pipe].each do |t|
+    [:inet, :unix, :fifo, :pipe, 'unix-dgram'].each do |t|
       it "accepts #{t}" do
         expect {
           described_class.new(title: "#{pcm_service}/#{t}", command: pcm_service)


### PR DESCRIPTION
Modern postfix supports a unix-dgram service type. This PR adds support for it in this module.